### PR TITLE
fix: 스메컴의 노멀맵 공유 문제 해결

### DIFF
--- a/TL2/Renderer.cpp
+++ b/TL2/Renderer.cpp
@@ -182,27 +182,35 @@ void URenderer::DrawIndexedPrimitiveComponent(UStaticMesh* InMesh, D3D11_PRIMITI
 
         for (uint32 i = 0; i < NumMeshGroupInfos; ++i)
         {
-            UMaterial* const Material = UResourceManager::GetInstance().Get<UMaterial>(InComponentMaterialSlots[i].MaterialName);
+            const FMaterialSlot& CurrentSlot = InComponentMaterialSlots[i]; //  현재 슬롯 정보를 가져옵니다.
+            UMaterial* const Material = UResourceManager::GetInstance().Get<UMaterial>(CurrentSlot.MaterialName);
+            UTexture* NormalTexture = nullptr; // 최종적으로 바인딩될 노멀 텍스처
             const FObjMaterialInfo& MaterialInfo = Material->GetMaterialInfo();
             bool bHasTexture = !(MaterialInfo.DiffuseTextureFileName == FName::None());
 
-            // Check for normal texture directly from the UMaterial instance
-            UTexture* NormalTexture = Material->GetNormalTexture();
-            bool bHasNormalTexture = (NormalTexture != nullptr);
+            // 오버라이드가 켜져있으면, 컴포넌트의 오버라이드 텍스처를 사용합니다.
+            if (CurrentSlot.bOverrideNormalTexture)
+            {
+                NormalTexture = CurrentSlot.NormalTextureOverride;
+            }
+            // 오버라이드가 꺼져있으면, 원본 머티리얼의 텍스처를 사용합니다.
+            else
+            {
+                NormalTexture = Material->GetNormalTexture();
+            }
 
-            // 재료 변경 추적
+            bool bHasNormalTexture = (NormalTexture != nullptr); // 머티리얼의 노말맵 보유 여부
+
             if (LastMaterial != Material)
             {
                 StatsCollector.IncrementMaterialChanges();
                 LastMaterial = const_cast<UMaterial*>(Material);
             }
 
-            // Diffuse Texture
             if (bHasTexture)
             {
                 FTextureData* TextureData = UResourceManager::GetInstance().CreateOrGetTextureData(MaterialInfo.DiffuseTextureFileName);
 
-                // 텍스처 변경 추적 (임시로 FTextureData*를 UTexture*로 캠스트)
                 UTexture* CurrentTexture = reinterpret_cast<UTexture*>(TextureData);
                 if (LastTexture != CurrentTexture)
                 {
@@ -213,16 +221,20 @@ void URenderer::DrawIndexedPrimitiveComponent(UStaticMesh* InMesh, D3D11_PRIMITI
                 RHIDevice->GetDeviceContext()->PSSetShaderResources(0, 1, &(TextureData->TextureSRV));
             }
 
-            // Normal Texture
+            // 노멀 맵이 존재한다면, 최종적으로 결정된 NormalTexture의 SRV를 바인딩합니다.
             if (bHasNormalTexture)
             {
                 ID3D11ShaderResourceView* NormalSRV = NormalTexture->GetShaderResourceView();
                 RHIDevice->GetDeviceContext()->PSSetShaderResources(1, 1, &NormalSRV);
             }
+            // 텍스처가 없는 경우, 슬롯을 명시적으로 비웁니다.
+            else
+            {
+                ID3D11ShaderResourceView* NullSRV = nullptr;
+                RHIDevice->GetDeviceContext()->PSSetShaderResources(1, 1, &NullSRV);
+            }
 
-            RHIDevice->UpdateSetCBuffer({ FMaterialInPs(MaterialInfo), (uint32)true, (uint32)bHasTexture, (uint32)bHasNormalTexture }); // PSSet도 해줌
-
-            // DrawCall 수실행 및 통계 추가
+            RHIDevice->UpdateSetCBuffer({ FMaterialInPs(MaterialInfo), (uint32)true, (uint32)bHasTexture, (uint32)bHasNormalTexture }); 
             RHIDevice->GetDeviceContext()->DrawIndexed(MeshGroupInfos[i].IndexCount, MeshGroupInfos[i].StartIndex, 0);
             StatsCollector.IncrementDrawCalls();
         }
@@ -230,7 +242,7 @@ void URenderer::DrawIndexedPrimitiveComponent(UStaticMesh* InMesh, D3D11_PRIMITI
     else
     {
         FObjMaterialInfo ObjMaterialInfo;
-        RHIDevice->UpdateSetCBuffer({ FMaterialInPs(ObjMaterialInfo), (uint32)false, (uint32)false, (uint32)false }); // PSSet도 해줌
+        RHIDevice->UpdateSetCBuffer({ FMaterialInPs(ObjMaterialInfo), (uint32)false, (uint32)false, (uint32)false }); 
         RHIDevice->GetDeviceContext()->DrawIndexed(IndexCount, 0, 0);
         StatsCollector.IncrementDrawCalls();
     }

--- a/TL2/Scene/QuickSave.Scene
+++ b/TL2/Scene/QuickSave.Scene
@@ -1,6 +1,6 @@
 {
   "Version" : 2,
-  "NextUUID" : 699,
+  "NextUUID" : 750,
   "PerspectiveCamera" : {
     "FOV" : [60.000000],
     "FarClip" : [4000.000000],
@@ -41,7 +41,7 @@
       "ParentComponentUUID" : 0,
       "Type" : "UStaticMeshComponent",
       "RelativeLocation" : [3.071271, 0.110701, 0.445936],
-      "RelativeRotation" : [-0.000022, -0.000005, 179.999939],
+      "RelativeRotation" : [-0.000036, -0.000005, 179.999908],
       "RelativeScale" : [1.000000, 1.000000, 1.000000],
       "StaticMesh" : "Data/ship/E-45-Aircraft/E 45 Aircraft_obj.obj"
     },
@@ -66,7 +66,7 @@
       "ParentComponentUUID" : 0,
       "Type" : "UStaticMeshComponent",
       "RelativeLocation" : [3.655819, 0.110701, 4.790642],
-      "RelativeRotation" : [83.662071, -1.901469, 90.025703],
+      "RelativeRotation" : [88.099380, -1.901476, 90.025696],
       "RelativeScale" : [1.000000, 1.000000, 1.000000],
       "StaticMesh" : "Data/ship/E-45-Aircraft/E 45 Aircraft_obj.obj"
     },
@@ -91,7 +91,7 @@
       "ParentComponentUUID" : 0,
       "Type" : "UStaticMeshComponent",
       "RelativeLocation" : [0.000000, 0.110701, 0.000000],
-      "RelativeRotation" : [-0.000022, -0.000005, 179.999939],
+      "RelativeRotation" : [-0.000036, -0.000005, 179.999908],
       "RelativeScale" : [1.000000, 1.000000, 1.000000],
       "StaticMesh" : "Data/ship/E-45-Aircraft/E 45 Aircraft_obj.obj"
     },
@@ -116,7 +116,7 @@
       "ParentComponentUUID" : 0,
       "Type" : "UStaticMeshComponent",
       "RelativeLocation" : [-3.202050, 0.110701, 4.790642],
-      "RelativeRotation" : [83.651817, -0.000005, 179.999939],
+      "RelativeRotation" : [83.651810, -0.000005, 179.999908],
       "RelativeScale" : [1.000000, 1.000000, 1.000000],
       "StaticMesh" : "Data/ship/E-45-Aircraft/E 45 Aircraft_obj.obj"
     },

--- a/TL2/StaticMeshComponent.h
+++ b/TL2/StaticMeshComponent.h
@@ -10,10 +10,18 @@ class UTexture;
 struct FPrimitiveData;
 struct FComponentData;
 
+/* *
+* @param bChangedByUser - Material의 UI를 통한 유저의 write 상태를 기록합니다.
+* @param bOverrideNormalTexture - true에서 NormalTextureOverride 값을 사용합니다.
+*           false에서 MaterialName에 해당하는 원본 머터리얼 노멀 맵을 사용합니다.
+* @param NormalTextureOverride - 유저가 수정한 오버라이드할 텍스처 포인터입니다.
+*/
 struct FMaterialSlot
 {
     FString MaterialName;
-    bool bChangedByUser = false; // user에 의해 직접 Material이 바뀐 적이 있는지.
+    UTexture* NormalTextureOverride = nullptr;
+    bool bOverrideNormalTexture = false; 
+    bool bChangedByUser = false; 
 };
 
 class UStaticMeshComponent : public UMeshComponent
@@ -31,6 +39,32 @@ public:
     void SetStaticMesh(const FString& PathFileName);
     UStaticMesh* GetStaticMesh() const { return StaticMesh; }
 
+    /**
+     * @brief 특정 슬롯의 노멀 맵 오버라이드를 설정합니다.
+     * @param SlotIndex 머티리얼 슬롯 인덱스
+     * @param InTexture 오버라이드할 텍스처. (nullptr은 'None'으로 오버라이드)
+     */
+    void SetNormalTextureOverride(int32 SlotIndex, UTexture* InTexture);
+
+    /**
+     * @brief 특정 슬롯의 노멀 맵 오버라이드를 제거하고 원본 머티리얼의 설정을 사용합니다.
+     * @param SlotIndex 머티리얼 슬롯 인덱스
+     */
+    void ClearNormalTextureOverride(int32 SlotIndex);
+
+    /**
+     * @brief 특정 슬롯의 노멀 맵 오버라이드 텍스처를 가져옵니다.
+     * @return 오버라이드가 활성화되어 있으면 텍스처(혹은 nullptr), 아니면 nullptr.
+     * @note 오버라이드 여부는 HasNormalTextureOverride로 확인해야 합니다.
+     */
+    UTexture* GetNormalTextureOverride(int32 SlotIndex) const;
+
+    /**
+     * @brief 특정 슬롯에 노멀 맵 오버라이드가 활성화되어 있는지 확인합니다.
+     * @return 오버라이드가 활성화되어 있으면 true
+     */
+    bool HasNormalTextureOverride(int32 SlotIndex) const;
+
     // 씬 포맷(FPrimitiveData)을 이용한 컴포넌트 직렬화/역직렬화
     // - bIsLoading == true  : InOut로부터 읽어서 컴포넌트 상태(메시) 설정
     // - bIsLoading == false : 컴포넌트 상태를 InOut에 기록
@@ -46,8 +80,6 @@ public:
     const FAABB& GetLocalAABB() const;
     UObject* Duplicate() override;
     void DuplicateSubObjects() override;
-
-
 
 protected:
     // [PIE] 주소 복사 / NOTE: 만약 복사 후에도 GPU 버퍼 내용을 다르게 갖고 싶은 경우 깊은 복사를 해서 버퍼를 2개 생성하는 방법도 고려

--- a/TL2/UI/Widget/TargetActorTransformWidget.h
+++ b/TL2/UI/Widget/TargetActorTransformWidget.h
@@ -63,13 +63,23 @@ private:
 	bool bUniformScale = false;
 	
 	// 헬퍼 메서드
-	//AActor* GetCurrentSelectedActor() const;
 	void ResetChangeFlags();
 
 	// Render component details func.
 	// TODO: define UComponentDetailsWidget class, add to ComponentWidgetRegistry (TMap)
 	void RenderExponentialHeightFogComponentDetails(UExponentialHeightFogComponent* InComponent);
+
+	/* *
+	* @brief StaticMeshComponent의 제어를 담당 및 렌더하는 함수입니다.
+	* @function - RenderStaticMeshSelector: 스태틱 메시 선택 UI를 렌더링합니다.
+	* @function - RenderMaterialSlots: 머티리얼 슬롯 목록 UI를 렌더링합니다.
+	* @function - RenderNormalMapSelector:머티리얼의 노멀 맵 선택 UI를 렌더링합니다.
+	*/
 	void RenderStaticMeshComponentDetails(UStaticMeshComponent* InComponent);
+	void RenderStaticMeshSelector(UStaticMeshComponent* InComponent);
+	void RenderMaterialSlots(UStaticMeshComponent* InComponent);
+	void RenderNormalMapSelector(UStaticMeshComponent* InComponent, int32 MaterialSlotIndex);
+
 	void RenderBillboardComponentDetails(UBillboardComponent* InComponent);
 	void RenderTextRenderComponentDetails(UTextRenderComponent* InComponent);
 	void RenderPointLightComponentDetails(UPointLightComponent* InComponent);


### PR DESCRIPTION
현상: 동일한 복수의 스메컴이 존재하고, 그 중 하나의 노멀 텍스쳐를 변경하면, 나머지 동일한 스메컴도 같이 적용되는 현상

원인: 리소스 매니저가 가진 material 자원을 모두 참조했기에 발생

해결: 스메컴의 FMaterialSlot을 확장하여 텍스쳐 갈이가 가능하도록 변경했습니다.